### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,3 @@ test
 gulpfile.js
 .travis.yml
 .gitignore
-.git


### PR DESCRIPTION
>  By default, the following paths and files are ignored, so there's no need to add them to .npmignore explicitly:
> 
> .*.swp
> ._*
> .DS_Store
> **.git**
> .hg
> .npmrc
> .lock-wscript
> .svn
> .wafpickle-*
> config.gypi
> CVS
> npm-debug.log